### PR TITLE
Publish docker image on push to main branch

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -1,0 +1,20 @@
+name: Publish Docker image
+on:
+  push:
+    branches:
+      - main
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: open-privacy/opv/main
+          tags: open-privacy/opv:latest


### PR DESCRIPTION
See: https://docs.github.com/en/actions/guides/publishing-docker-images#publishing-images-to-github-packages

Publish on every push to main instead of on every release.