### PR TITLE
Fix handling of fact uniqueness error

### DIFF
--- a/functional_test/functional_test.go
+++ b/functional_test/functional_test.go
@@ -27,6 +27,10 @@ var TESTENV = struct {
 	DefaultDomain        string `env:"TESTENV_DEFAULT_DOMAIN" envDefault:"example.com"`
 }{}
 
+func generateScopeID() string {
+	return uniuri.NewLen(uniuri.UUIDLen)
+}
+
 var assertGetToken = func(t *testing.T, allowedHttpMethods []string) string {
 	var token string
 	Test(
@@ -141,7 +145,7 @@ func TestCreateFact(t *testing.T) {
 	token := assertGetToken(t, []string{"POST"})
 
 	t.Run("happy code path", func(t *testing.T) {
-		scopeID := uniuri.NewLen(uniuri.UUIDLen)
+		scopeID := generateScopeID()
 		factTypeSlug := "ssn"
 
 		Test(
@@ -165,7 +169,7 @@ func TestCreateFact(t *testing.T) {
 
 	t.Run("fact uniqueness", func(t *testing.T) {
 		factValue := fmt.Sprintf("%d%s", time.Now().UnixNano(), "_secret")
-		scopeID := uniuri.NewLen(uniuri.UUIDLen)
+		scopeID := generateScopeID()
 
 		assertCreateFact(t, token, scopeID, factValue)
 		Test(
@@ -186,7 +190,7 @@ func TestCreateFact(t *testing.T) {
 
 	t.Run("ssn fact type slug", func(t *testing.T) {
 		t.Run("valid ssns", func(t *testing.T) {
-			scopeID := uniuri.NewLen(uniuri.UUIDLen)
+			scopeID := generateScopeID()
 			factTypeSlug := "ssn"
 			validSSNs := []string{
 				"123-45-6789",
@@ -214,7 +218,7 @@ func TestCreateFact(t *testing.T) {
 		})
 
 		t.Run("error with invalid ssn", func(t *testing.T) {
-			scopeID := uniuri.NewLen(uniuri.UUIDLen)
+			scopeID := generateScopeID()
 			factTypeSlug := "ssn"
 			invalidSSNs := []string{
 				"invalid",
@@ -244,7 +248,7 @@ func TestCreateFact(t *testing.T) {
 func TestGetFact(t *testing.T) {
 	token := assertGetToken(t, []string{"POST", "GET"})
 	factValue := fmt.Sprintf("%d%s", time.Now().UnixNano(), "_secret")
-	scopeID := uniuri.NewLen(uniuri.UUIDLen)
+	scopeID := generateScopeID()
 	factID := assertCreateFact(t, token, scopeID, factValue)
 
 	t.Run("happy code path", func(t *testing.T) {

--- a/pkg/repo/repo_ent_impl.go
+++ b/pkg/repo/repo_ent_impl.go
@@ -150,7 +150,8 @@ func (e *entImpl) HandleError(ctx context.Context, err error) error {
 		return NewValidationError(err, "Validation error")
 	}
 	if ent.IsConstraintError(err) {
-		if strings.Contains(err.Error(), "UNIQUE constraint failed: facts.hashed_value, facts.scope_facts, facts.fact_type_facts") {
+		var errorMessage = strings.ToLower(err.Error())
+		if strings.Contains(errorMessage, "unique constraint") && strings.Contains(errorMessage, "insert node to table \"facts\"") {
 			return NewValidationError(err, "fact_value already exists for this scope")
 		}
 	}


### PR DESCRIPTION
This makes handling of constraint error rely on ent message, instead of DB engine error message.