### PR TITLE
Upgrade ent to 0.7.0

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -1,5 +1,5 @@
 FROM golang:1.16
 WORKDIR /data/opv
 RUN curl -sf https://gobinaries.com/myitcv/gobin | sh
-RUN gobin entgo.io/ent/cmd/ent@v0.6.0
+RUN gobin entgo.io/ent/cmd/ent@v0.7.0
 RUN gobin github.com/swaggo/swag/cmd/swag@v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/open-privacy/opv
 go 1.16
 
 require (
-	entgo.io/ent v0.6.0
+	entgo.io/ent v0.7.0
 	github.com/Blank-Xu/sql-adapter v0.0.0-20201228072413-5276c89fa383
 	github.com/Eun/go-hit v0.5.20
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
@@ -17,7 +17,7 @@ require (
 	github.com/labstack/echo-contrib v0.9.1-0.20210210084017-7944b61cc275
 	github.com/labstack/echo/v4 v4.2.1
 	github.com/labstack/gommon v0.3.0
-	github.com/lib/pq v1.9.0
+	github.com/lib/pq v1.10.0
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-sqlite3 v1.14.6
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqCl
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-entgo.io/ent v0.6.0 h1:oo/a8sXPQKzHYFlVwmwOnyzBy+u8FWQsoLLqFCrOBt0=
-entgo.io/ent v0.6.0/go.mod h1:+Y513RSj+qleCpyeCmF8leXqAAhCYDJfpzGPIAFPBxc=
+entgo.io/ent v0.7.0 h1:E3EjO0cUL61DvUg5ZEZdxa4yTL+4SuZv0LqBExo8CQA=
+entgo.io/ent v0.7.0/go.mod h1:HZZJxglL8ro4OVDmM06lijj4bOTGcaDdrZttDZ8fVJs=
 github.com/Blank-Xu/sql-adapter v0.0.0-20201228072413-5276c89fa383 h1:N2kDqeDcGrTN6fnONcGDXgUZFbcl3kdDahjlpyXP/r0=
 github.com/Blank-Xu/sql-adapter v0.0.0-20201228072413-5276c89fa383/go.mod h1:otHZ0YO8AoGTHke27mhANH8T9Q9lPh7bp1T8uHREk9E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -249,8 +249,8 @@ github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
-github.com/lib/pq v1.9.0 h1:L8nSXQQzAYByakOFMTwpjRoHsMJklur4Gi59b6VivR8=
-github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.10.0 h1:Zx5DJFEYQXio93kgXnQ09fXNiUKsqv4OUEu2UtGcB1E=
+github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lunixbochs/vtclean v1.0.0 h1:xu2sLAri4lGiovBDQKxl5mrXyESr3gUr5m5SM5+LVb8=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -270,7 +270,6 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
@@ -296,7 +295,7 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -343,7 +342,7 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
+github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -388,7 +387,7 @@ github.com/zhouzhuojie/iso8601ms v0.1.0/go.mod h1:4t5F1H6mzxsFB9CCFhj1pUlK8TPwRG
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
-go.opencensus.io v0.22.6/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
+go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
@@ -494,6 +493,7 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 h1:46ULzRKLh1CwgRq2dC5SlBzEqqNCi8rreOZnNrbqcIY=
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -536,8 +536,8 @@ golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20201026223136-e84cfc6dd5ca/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201120155355-20be4ac4bd6e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201207182000-5679438983bd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20210105164027-a548c3f4af2d h1:v9TQ4+tS+0r4R+9E6svkcl6ocSxeHONeVkK2y6YhzmA=
-golang.org/x/tools v0.0.0-20210105164027-a548c3f4af2d/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -594,7 +594,6 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/pkg/ent/apiaudit/apiaudit.go
+++ b/pkg/ent/apiaudit/apiaudit.go
@@ -29,7 +29,6 @@ const (
 	FieldHTTPMethod = "http_method"
 	// FieldSentHTTPStatus holds the string denoting the sent_http_status field in the database.
 	FieldSentHTTPStatus = "sent_http_status"
-
 	// Table holds the table name of the apiaudit in the database.
 	Table = "api_audits"
 )

--- a/pkg/ent/apiaudit_query.go
+++ b/pkg/ent/apiaudit_query.go
@@ -334,7 +334,7 @@ func (aaq *APIAuditQuery) sqlCount(ctx context.Context) (int, error) {
 func (aaq *APIAuditQuery) sqlExist(ctx context.Context) (bool, error) {
 	n, err := aaq.sqlCount(ctx)
 	if err != nil {
-		return false, fmt.Errorf("ent: check existence: %v", err)
+		return false, fmt.Errorf("ent: check existence: %w", err)
 	}
 	return n > 0, nil
 }

--- a/pkg/ent/client.go
+++ b/pkg/ent/client.go
@@ -79,7 +79,7 @@ func (c *Client) Tx(ctx context.Context) (*Tx, error) {
 	}
 	tx, err := newTx(ctx, c.driver)
 	if err != nil {
-		return nil, fmt.Errorf("ent: starting a transaction: %v", err)
+		return nil, fmt.Errorf("ent: starting a transaction: %w", err)
 	}
 	cfg := c.config
 	cfg.driver = tx
@@ -103,7 +103,7 @@ func (c *Client) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) 
 		BeginTx(context.Context, *sql.TxOptions) (dialect.Tx, error)
 	}).BeginTx(ctx, opts)
 	if err != nil {
-		return nil, fmt.Errorf("ent: starting a transaction: %v", err)
+		return nil, fmt.Errorf("ent: starting a transaction: %w", err)
 	}
 	cfg := c.config
 	cfg.driver = &txDriver{tx: tx, drv: c.driver}

--- a/pkg/ent/ent.go
+++ b/pkg/ent/ent.go
@@ -5,7 +5,6 @@ package ent
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
@@ -238,22 +237,8 @@ func IsConstraintError(err error) bool {
 }
 
 func isSQLConstraintError(err error) (*ConstraintError, bool) {
-	var (
-		msg = err.Error()
-		// error format per dialect.
-		errors = [...]string{
-			"Error 1062",               // MySQL 1062 error (ER_DUP_ENTRY).
-			"UNIQUE constraint failed", // SQLite.
-			"duplicate key value violates unique constraint", // PostgreSQL.
-		}
-	)
-	if _, ok := err.(*sqlgraph.ConstraintError); ok {
-		return &ConstraintError{msg, err}, true
-	}
-	for i := range errors {
-		if strings.Contains(msg, errors[i]) {
-			return &ConstraintError{msg, err}, true
-		}
+	if sqlgraph.IsConstraintError(err) {
+		return &ConstraintError{err.Error(), err}, true
 	}
 	return nil, false
 }
@@ -261,7 +246,7 @@ func isSQLConstraintError(err error) (*ConstraintError, bool) {
 // rollback calls tx.Rollback and wraps the given error with the rollback error if present.
 func rollback(tx dialect.Tx, err error) error {
 	if rerr := tx.Rollback(); rerr != nil {
-		err = fmt.Errorf("%s: %v", err.Error(), rerr)
+		err = fmt.Errorf("%w: %v", err, rerr)
 	}
 	if err, ok := isSQLConstraintError(err); ok {
 		return err

--- a/pkg/ent/fact/fact.go
+++ b/pkg/ent/fact/fact.go
@@ -23,12 +23,10 @@ const (
 	FieldEncryptedValue = "encrypted_value"
 	// FieldDomain holds the string denoting the domain field in the database.
 	FieldDomain = "domain"
-
 	// EdgeScope holds the string denoting the scope edge name in mutations.
 	EdgeScope = "scope"
 	// EdgeFactType holds the string denoting the fact_type edge name in mutations.
 	EdgeFactType = "fact_type"
-
 	// Table holds the table name of the fact in the database.
 	Table = "facts"
 	// ScopeTable is the table the holds the scope relation/edge.
@@ -58,7 +56,8 @@ var Columns = []string{
 	FieldDomain,
 }
 
-// ForeignKeys holds the SQL foreign-keys that are owned by the Fact type.
+// ForeignKeys holds the SQL foreign-keys that are owned by the "facts"
+// table and are not defined as standalone fields in the schema.
 var ForeignKeys = []string{
 	"fact_type_facts",
 	"scope_facts",

--- a/pkg/ent/fact_create.go
+++ b/pkg/ent/fact_create.go
@@ -316,6 +316,7 @@ func (fc *FactCreate) createSpec() (*Fact, *sqlgraph.CreateSpec) {
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
+		_node.scope_facts = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := fc.mutation.FactTypeIDs(); len(nodes) > 0 {
@@ -335,6 +336,7 @@ func (fc *FactCreate) createSpec() (*Fact, *sqlgraph.CreateSpec) {
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
+		_node.fact_type_facts = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/pkg/ent/fact_query.go
+++ b/pkg/ent/fact_query.go
@@ -414,7 +414,8 @@ func (fq *FactQuery) sqlAll(ctx context.Context) ([]*Fact, error) {
 		ids := make([]string, 0, len(nodes))
 		nodeids := make(map[string][]*Fact)
 		for i := range nodes {
-			if fk := nodes[i].scope_facts; fk != nil {
+			fk := nodes[i].scope_facts
+			if fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -439,7 +440,8 @@ func (fq *FactQuery) sqlAll(ctx context.Context) ([]*Fact, error) {
 		ids := make([]string, 0, len(nodes))
 		nodeids := make(map[string][]*Fact)
 		for i := range nodes {
-			if fk := nodes[i].fact_type_facts; fk != nil {
+			fk := nodes[i].fact_type_facts
+			if fk != nil {
 				ids = append(ids, *fk)
 				nodeids[*fk] = append(nodeids[*fk], nodes[i])
 			}
@@ -471,7 +473,7 @@ func (fq *FactQuery) sqlCount(ctx context.Context) (int, error) {
 func (fq *FactQuery) sqlExist(ctx context.Context) (bool, error) {
 	n, err := fq.sqlCount(ctx)
 	if err != nil {
-		return false, fmt.Errorf("ent: check existence: %v", err)
+		return false, fmt.Errorf("ent: check existence: %w", err)
 	}
 	return n > 0, nil
 }

--- a/pkg/ent/facttype/facttype.go
+++ b/pkg/ent/facttype/facttype.go
@@ -23,10 +23,8 @@ const (
 	FieldBuiltIn = "built_in"
 	// FieldValidation holds the string denoting the validation field in the database.
 	FieldValidation = "validation"
-
 	// EdgeFacts holds the string denoting the facts edge name in mutations.
 	EdgeFacts = "facts"
-
 	// Table holds the table name of the facttype in the database.
 	Table = "fact_types"
 	// FactsTable is the table the holds the facts relation/edge.

--- a/pkg/ent/facttype_query.go
+++ b/pkg/ent/facttype_query.go
@@ -406,7 +406,7 @@ func (ftq *FactTypeQuery) sqlCount(ctx context.Context) (int, error) {
 func (ftq *FactTypeQuery) sqlExist(ctx context.Context) (bool, error) {
 	n, err := ftq.sqlCount(ctx)
 	if err != nil {
-		return false, fmt.Errorf("ent: check existence: %v", err)
+		return false, fmt.Errorf("ent: check existence: %w", err)
 	}
 	return n > 0, nil
 }

--- a/pkg/ent/grant/grant.go
+++ b/pkg/ent/grant/grant.go
@@ -25,7 +25,6 @@ const (
 	FieldVersion = "version"
 	// FieldAllowedHTTPMethods holds the string denoting the allowed_http_methods field in the database.
 	FieldAllowedHTTPMethods = "allowed_http_methods"
-
 	// Table holds the table name of the grant in the database.
 	Table = "grants"
 )

--- a/pkg/ent/grant_query.go
+++ b/pkg/ent/grant_query.go
@@ -334,7 +334,7 @@ func (gq *GrantQuery) sqlCount(ctx context.Context) (int, error) {
 func (gq *GrantQuery) sqlExist(ctx context.Context) (bool, error) {
 	n, err := gq.sqlCount(ctx)
 	if err != nil {
-		return false, fmt.Errorf("ent: check existence: %v", err)
+		return false, fmt.Errorf("ent: check existence: %w", err)
 	}
 	return n > 0, nil
 }

--- a/pkg/ent/migrate/migrate.go
+++ b/pkg/ent/migrate/migrate.go
@@ -48,7 +48,7 @@ func NewSchema(drv dialect.Driver) *Schema { return &Schema{drv: drv} }
 func (s *Schema) Create(ctx context.Context, opts ...schema.MigrateOption) error {
 	migrate, err := schema.NewMigrate(s.drv, opts...)
 	if err != nil {
-		return fmt.Errorf("ent/migrate: %v", err)
+		return fmt.Errorf("ent/migrate: %w", err)
 	}
 	return migrate.Create(ctx, Tables...)
 }
@@ -66,7 +66,7 @@ func (s *Schema) WriteTo(ctx context.Context, w io.Writer, opts ...schema.Migrat
 	}
 	migrate, err := schema.NewMigrate(drv, opts...)
 	if err != nil {
-		return fmt.Errorf("ent/migrate: %v", err)
+		return fmt.Errorf("ent/migrate: %w", err)
 	}
 	return migrate.Create(ctx, Tables...)
 }

--- a/pkg/ent/migrate/schema.go
+++ b/pkg/ent/migrate/schema.go
@@ -99,16 +99,14 @@ var (
 		PrimaryKey: []*schema.Column{FactsColumns[0]},
 		ForeignKeys: []*schema.ForeignKey{
 			{
-				Symbol:  "facts_fact_types_facts",
-				Columns: []*schema.Column{FactsColumns[7]},
-
+				Symbol:     "facts_fact_types_facts",
+				Columns:    []*schema.Column{FactsColumns[7]},
 				RefColumns: []*schema.Column{FactTypesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
-				Symbol:  "facts_scopes_facts",
-				Columns: []*schema.Column{FactsColumns[8]},
-
+				Symbol:     "facts_scopes_facts",
+				Columns:    []*schema.Column{FactsColumns[8]},
 				RefColumns: []*schema.Column{ScopesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -153,7 +151,7 @@ var (
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "slug", Type: field.TypeString},
-		{Name: "built_in", Type: field.TypeBool},
+		{Name: "built_in", Type: field.TypeBool, Default: false},
 		{Name: "validation", Type: field.TypeString, Nullable: true},
 	}
 	// FactTypesTable holds the schema information for the "fact_types" table.

--- a/pkg/ent/runtime/runtime.go
+++ b/pkg/ent/runtime/runtime.go
@@ -5,6 +5,6 @@ package runtime
 // The schema-stitching logic is generated in github.com/open-privacy/opv/pkg/ent/runtime.go
 
 const (
-	Version = "v0.6.0"                                          // Version of ent codegen.
-	Sum     = "h1:oo/a8sXPQKzHYFlVwmwOnyzBy+u8FWQsoLLqFCrOBt0=" // Sum of ent codegen.
+	Version = "v0.7.0"                                          // Version of ent codegen.
+	Sum     = "h1:E3EjO0cUL61DvUg5ZEZdxa4yTL+4SuZv0LqBExo8CQA=" // Sum of ent codegen.
 )

--- a/pkg/ent/scope/scope.go
+++ b/pkg/ent/scope/scope.go
@@ -23,10 +23,8 @@ const (
 	FieldNonce = "nonce"
 	// FieldDomain holds the string denoting the domain field in the database.
 	FieldDomain = "domain"
-
 	// EdgeFacts holds the string denoting the facts edge name in mutations.
 	EdgeFacts = "facts"
-
 	// Table holds the table name of the scope in the database.
 	Table = "scopes"
 	// FactsTable is the table the holds the facts relation/edge.

--- a/pkg/ent/scope_query.go
+++ b/pkg/ent/scope_query.go
@@ -406,7 +406,7 @@ func (sq *ScopeQuery) sqlCount(ctx context.Context) (int, error) {
 func (sq *ScopeQuery) sqlExist(ctx context.Context) (bool, error) {
 	n, err := sq.sqlCount(ctx)
 	if err != nil {
-		return false, fmt.Errorf("ent: check existence: %v", err)
+		return false, fmt.Errorf("ent: check existence: %w", err)
 	}
 	return n > 0, nil
 }


### PR DESCRIPTION
Changelog of ent 0.7.0
https://github.com/ent/ent/releases/tag/v0.7.0


For local development, we may need to run `make vendor` to update local vendor files.