### PR TITLE
Add omitempty for scope_custom_id

### DIFF
--- a/functional_test/functional_test.go
+++ b/functional_test/functional_test.go
@@ -242,7 +242,7 @@ func TestCreateFactUniqueScopeConstraint(t *testing.T) {
 
 				Expect().Status().Equal(http.StatusOK),
 				Expect().Body().JSON().JQ(".id").NotEqual(""),
-				Expect().Body().JSON().JQ(".scope_custom_id").Equal(""),
+				Expect().Body().JSON().JQ(".scope_custom_id").Equal(nil),
 				Expect().Body().JSON().JQ(".fact_type_slug").Equal("ssn"),
 			)
 		}

--- a/pkg/apimodel/fact.go
+++ b/pkg/apimodel/fact.go
@@ -10,7 +10,7 @@ type CreateFact struct {
 // Fact represents a fact
 type Fact struct {
 	ID            string `json:"id"`
-	ScopeCustomID string `json:"scope_custom_id"`
+	ScopeCustomID string `json:"scope_custom_id,omitempty"`
 	FactTypeSlug  string `json:"fact_type_slug"`
 	Domain        string `json:"domain"`
 	Value         string `json:"value,omitempty"`


### PR DESCRIPTION
Sample response:

```
{
  "id": "fact_LvGLY4EEFmcqPzMpAIRl",
  "fact_type_slug": "ssn",
  "domain": "example.com"
}
```