### PR TITLE
Add checkr api demo

### DIFF
--- a/docs/openprivacy.io/content/docs/development/playground.md
+++ b/docs/openprivacy.io/content/docs/development/playground.md
@@ -13,8 +13,10 @@ toc: true
 
 Testing via the Data Plane of `https://playground.openprivacy.io`.
 
-<iframe width="100%" height="300" src="//jsfiddle.net/howvu08j/embedded/result,js,html,css/dark/" allowfullscreen="allowfullscreen" allowpaymentrequest frameborder="0"></iframe>
+<iframe width="100%" height="500" src="//jsfiddle.net/howvu08j/embedded/result,js,html,css/dark/" allowfullscreen="allowfullscreen" allowpaymentrequest frameborder="0"></iframe>
+
+----
 
 ## Checkr API Proxy Demo
 
-TODO
+<iframe width="100%" height="600" src="//jsfiddle.net/682vwdtu/2/embedded/result,js,html,css/dark/" allowfullscreen="allowfullscreen" allowpaymentrequest frameborder="0"></iframe>

--- a/docs/openprivacy.io/content/docs/development/playground.md
+++ b/docs/openprivacy.io/content/docs/development/playground.md
@@ -13,7 +13,7 @@ toc: true
 
 Testing via the Data Plane of `https://playground.openprivacy.io`.
 
-<iframe width="100%" height="500" src="//jsfiddle.net/howvu08j/embedded/result,js,html,css/dark/" allowfullscreen="allowfullscreen" allowpaymentrequest frameborder="0"></iframe>
+<iframe width="100%" height="400" src="//jsfiddle.net/howvu08j/embedded/result,js,html,css/dark/" allowfullscreen="allowfullscreen" allowpaymentrequest frameborder="0"></iframe>
 
 ----
 


### PR DESCRIPTION
This PR uses the checkr sandbox api to demo the detokenize proxy.

- Detokenize proxy: https://proxy-playground.openprivacy.io/detokenize_checkr_api
- A UI jsfiddle playground demo
- PIIs are from the testing demo of Checkr API https://docs.checkr.com/#operation/createCandidate


![image](https://user-images.githubusercontent.com/658840/112253258-982ca380-8c1b-11eb-9c50-33979340263e.png)


![image](https://user-images.githubusercontent.com/658840/112253273-9fec4800-8c1b-11eb-8d6a-316a8e39249d.png)


![image](https://user-images.githubusercontent.com/658840/112253293-ab3f7380-8c1b-11eb-93bd-6a0b32e759e0.png)
